### PR TITLE
Audience accounts/sc 104607/update GitHub actions to remove deprecation

### DIFF
--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -43,6 +43,7 @@ ${check_output}
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
 
-    echo "promtool_output=${check_output}" >> $GITHUB_OUTPUT
+    echo ::set-output name=promtool_output::${check_output}
+#    echo "promtool_output=${check_output}" >> ${}GITHUB_OUTPUT}
     exit ${check_exit_code}
 }

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -46,7 +46,8 @@ ${check_output}
     fi
 
 #    echo ::set-output name=promtool_output::${check_output}
-    echo "promtool_output=${check_output}"
-    echo "promtool_output=${check_output}" >> "$GITHUB_OUTPUT"
+    echo "promtool_output=<<EOF" >> "$GITHUB_OUTPUT"
+    echo "${check_output}" >> "$GITHUB_OUTPUT"
+    echo "EOF" >> "$GITHUB_OUTPUT"
     exit ${check_exit_code}
 }

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ex
+
 function promtool_check {
 
     # gather check promtool output

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -43,6 +43,6 @@ ${check_output}
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=promtool_output::${check_output}
+    echo "promtool_output=${check_output}" >> $GITHUB_OUTPUT
     exit ${check_exit_code}
 }

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -ex
-
 function promtool_check {
 
     # gather check promtool output
@@ -44,7 +42,6 @@ ${check_output}
         echo "check: info: commenting on the pull request"
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
-
 
     # Updated to new GITHUB_OUTPUT format https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
     # Modified to support multi-line output https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -46,7 +46,7 @@ ${check_output}
     fi
 
 #    echo ::set-output name=promtool_output::${check_output}
-    echo "promtool_output=<<EOF" >> "$GITHUB_OUTPUT"
+    echo "promtool_output<<EOF" >> "$GITHUB_OUTPUT"
     echo "${check_output}" >> "$GITHUB_OUTPUT"
     echo "EOF" >> "$GITHUB_OUTPUT"
     exit ${check_exit_code}

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -45,7 +45,9 @@ ${check_output}
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
 
-#    echo ::set-output name=promtool_output::${check_output}
+
+    # Updated to new GITHUB_OUTPUT format https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
+    # Modified to support multi-line output https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
     echo "promtool_output<<EOF" >> "$GITHUB_OUTPUT"
     echo "${check_output}" >> "$GITHUB_OUTPUT"
     echo "EOF" >> "$GITHUB_OUTPUT"

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -43,7 +43,7 @@ ${check_output}
         echo "${check_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${check_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=promtool_output::${check_output}
-#    echo "promtool_output=${check_output}" >> ${}GITHUB_OUTPUT}
+#    echo ::set-output name=promtool_output::${check_output}
+    echo "promtool_output=${check_output}" >> "$GITHUB_OUTPUT"
     exit ${check_exit_code}
 }

--- a/src/promtool_check.sh
+++ b/src/promtool_check.sh
@@ -44,6 +44,7 @@ ${check_output}
     fi
 
 #    echo ::set-output name=promtool_output::${check_output}
+    echo "promtool_output=${check_output}"
     echo "promtool_output=${check_output}" >> "$GITHUB_OUTPUT"
     exit ${check_exit_code}
 }


### PR DESCRIPTION
Fork of the promtool-action project, it hasn't been updated in years.
Have updated the job to fix the deprecated set-output syntax.

Have two test runs:
* Successful `Validate prometheus alerts` with [no warnings](https://github.com/Attest/bids-svc/actions/runs/8601967790)
* Previous `Validate prometheus alerts` with [set-output warning](https://github.com/Attest/bids-svc/actions/runs/5056027257)