### PR TITLE
fix: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Attest/audience-accounts


### PR DESCRIPTION
Adding A&A as owners due to [purespectrum-panel-svc](https://github.com/Attest/purespectrum-panel-svc/blob/main/.github/workflows/validate-prometheus-config.yaml) uses this.